### PR TITLE
remove HSR names from cloud message

### DIFF
--- a/domestic_robotics/perception.ipynb
+++ b/domestic_robotics/perception.ipynb
@@ -212,7 +212,7 @@
      "output_type": "stream",
      "text": [
       "Oh no type doesn't match:\t type(cloud_msg) == PointCloud2 ? False\n",
-      "Actual type:\t\t\t type(cloud_msg) = <class 'tmp66L2o8._sensor_msgs__PointCloud2'>\n",
+      "Actual type:\t\t\t type(cloud_msg) = <class 'tmpTV2Olt._sensor_msgs__PointCloud2'>\n",
       "All is good now:\t\t type(cloud_msg) == PointCloud2 ? True\n"
      ]
     }
@@ -367,7 +367,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "estimated noodle box pose (frame head_rgbd_sensor_rgb_frame): x=0.029, y=-0.179, z=0.796\n"
+      "estimated noodle box pose (frame camera_link): x=0.029, y=-0.179, z=0.796\n"
      ]
     }
    ],


### PR DESCRIPTION
Just a small fix for removing HSR related topic names and frame ID from the `rosbag` message, since I'd like to use this bag file for testing in another repo.